### PR TITLE
ag/refactor

### DIFF
--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,9 +1,9 @@
-import
-  (
-    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
-    fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-      sha256 = lock.nodes.flake-compat.locked.narHash;
-    }
-  )
-  { src = ./.; }
+import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -53,7 +53,28 @@
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "nixpkgs-latest": "nixpkgs-latest",
+        "treefmt-nix": "treefmt-nix",
         "utils": "utils"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-latest"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742370146,
+        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     },
     "utils": {
@@ -68,6 +89,7 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -32,10 +32,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-latest": {
+      "locked": {
+        "lastModified": 1742069588,
+        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-latest": "nixpkgs-latest",
         "utils": "utils"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -18,17 +18,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733229606,
-        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
+        "lastModified": 1738644632,
+        "narHash": "sha256-DyvJjOOGmTSkkEfHq0oWkwtZOgejYIB5S865wmf/qos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "rev": "95ea544c84ebed84a31896b0ecea2570e5e0e236",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "rev": "95ea544c84ebed84a31896b0ecea2570e5e0e236",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
           settings.formatter = {
             nixfmt = {
               excludes = [
-                "yarn-manifest.nix"
+                "**/yarn-manifest.nix"
               ];
               includes = lib.mkForce [
                 "*.nix"
@@ -87,14 +87,31 @@
               ];
             };
           };
-          settings.global.on-unmatched = "info";
-          settings.global.excludes = [
-            ".yarn/*"
-          ];
+          settings.global = {
+            on-unmatched = "info";
+            excludes = [
+              "**/.git*"
+              "**/.pnp.*"
+              "*.js"
+              "*.json"
+              "*.md"
+              "*.sh"
+              "*.txt"
+              "*.yml"
+              "*/.yarn/*"
+              ".envrc"
+              "LICENSE"
+              "package.json"
+              "test/workspace/*"
+              "yarn-manifest.nix"
+            ];
+          };
         };
+        treefmt-package = treefmt-eval.config.build.wrapper;
       in
       {
         packages = rec {
+          treefmt = treefmt-package;
           default = pkgs.yarn-plugin-yarnpnp2nix;
           yarn-plugin = pkgs.yarn-plugin-yarnpnp2nix;
           yarnBerry = pkgs.yarnBerry;
@@ -139,7 +156,7 @@
               nodejs
               yarnBerry
               pkgs-latest.nixfmt-rfc-style
-              treefmt-eval.config.build.wrapper
+              treefmt-package
             ];
           };
           tests-patch = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -2,26 +2,41 @@
   description = "yarnpnp2nix";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs?rev=95ea544c84ebed84a31896b0ecea2570e5e0e236;
-    utils.url = github:numtide/flake-utils;
-    flake-compat ={
+    nixpkgs.url = "github:nixos/nixpkgs?rev=95ea544c84ebed84a31896b0ecea2570e5e0e236";
+    nixpkgs-latest.url = "github:nixos/nixpkgs?rev=c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5";
+    utils.url = "github:numtide/flake-utils";
+    flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, utils, ... }:
+  outputs =
+    {
+      nixpkgs,
+      nixpkgs-latest,
+      utils,
+      ...
+    }:
     let
       overlay = final: prev: {
-        yarnBerry = final.callPackage ./yarn.nix {};
-        yarn-plugin-yarnpnp2nix = final.callPackage ./yarnPlugin.nix {};
-        yarnpnp2nixLib = import ./lib/mkYarnPackage.nix { defaultPkgs = final; lib = final.lib; };
+        yarnBerry = final.callPackage ./yarn.nix { };
+        yarn-plugin-yarnpnp2nix = final.callPackage ./yarnPlugin.nix { };
+        yarnpnp2nixLib = import ./lib/mkYarnPackage.nix {
+          defaultPkgs = final;
+          lib = final.lib;
+        };
       };
-    in (utils.lib.eachDefaultSystem (system:
+    in
+    (utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [overlay];
+          overlays = [ overlay ];
+        };
+        pkgs-latest = import nixpkgs-latest {
+          inherit system;
         };
         inherit (pkgs) lib;
       in
@@ -44,22 +59,23 @@
             '';
           };
           tests = {
-            patch = let
-              workspace = pkgs.yarnpnp2nixLib.mkYarnPackagesFromManifest {
-                yarnManifest = import ./tests/patch/yarn-manifest.nix;
-              };
-            in
-            pkgs.runCommand "test-patch" {} ''
-              result=$(${lib.getExe workspace."three@workspace:packages/three"})
-              echo result: $result
+            patch =
+              let
+                workspace = pkgs.yarnpnp2nixLib.mkYarnPackagesFromManifest {
+                  yarnManifest = import ./tests/patch/yarn-manifest.nix;
+                };
+              in
+              pkgs.runCommand "test-patch" { } ''
+                result=$(${lib.getExe workspace."three@workspace:packages/three"})
+                echo result: $result
 
-              if [[ $result == true ]]; then
-                echo ok > $out
-              else
-                echo "expected true, got: $result"
-                exit 1
-              fi
-            '';
+                if [[ $result == true ]]; then
+                  echo ok > $out
+                else
+                  echo "expected true, got: $result"
+                  exit 1
+                fi
+              '';
           };
         };
         devShells = {
@@ -67,6 +83,12 @@
             packages = with pkgs; [
               nodejs
               yarnBerry
+              pkgs-latest.nixfmt-rfc-style
+              (pkgs-latest.nixfmt-tree.override {
+                settings.formatter.nixfmt.excludes = [
+                  "yarn-manifest.nix"
+                ];
+              })
             ];
           };
           tests-patch = pkgs.mkShell {
@@ -82,7 +104,7 @@
         lib = pkgs.yarnpnp2nixLib;
       }
     ))
-    //
-    { overlays.default = overlay; }
-  ;
+    // {
+      overlays.default = overlay;
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
                 };
               in
               pkgs.runCommand "test-patch" { } ''
-                result=$(${lib.getExe workspace."three@workspace:packages/three"})
+                result=$(${workspace."three@workspace:packages/three"}/bin/three)
                 echo result: $result
 
                 if [[ $result == true ]]; then

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,9 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?rev=95ea544c84ebed84a31896b0ecea2570e5e0e236";
     nixpkgs-latest.url = "github:nixos/nixpkgs?rev=c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5";
-    utils.url = "github:numtide/flake-utils";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs-latest";
+    utils.url = "github:numtide/flake-utils?rev=6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -16,6 +18,7 @@
       nixpkgs,
       nixpkgs-latest,
       utils,
+      treefmt-nix,
       ...
     }:
     let
@@ -39,6 +42,56 @@
           inherit system;
         };
         inherit (pkgs) lib;
+        treefmt-eval = (import treefmt-nix).evalModule pkgs {
+          programs.nixfmt.enable = true;
+          # programs.nixfmt.srict = true;
+          programs.dprint.enable = true;
+          programs.dprint = {
+            includes = lib.mkForce [
+              "**/*.ts"
+            ];
+          };
+          programs.dprint.settings = {
+            plugins = [
+              "https://plugins.dprint.dev/typescript-0.94.0.wasm"
+            ];
+            indentWidth = 2;
+            lineWidth = 100;
+            incremental = true;
+            useTabs = false;
+            typescript = {
+              "arrowFunction.useParentheses" = "preferNone";
+              "binaryExpression.linePerExpression" = true;
+              "enumDeclaration.memberSpacing" = "newLine";
+              "jsx.quoteStyle" = "preferSingle";
+              lineWidth = 80;
+              "memberExpression.linePerExpression" = true;
+              nextControlFlowPosition = "sameLine";
+              quoteProps = "asNeeded";
+              quoteStyle = "preferSingle";
+              semiColons = "asi";
+            };
+          };
+          settings.formatter = {
+            nixfmt = {
+              excludes = [
+                "yarn-manifest.nix"
+              ];
+              includes = lib.mkForce [
+                "*.nix"
+              ];
+            };
+            dprint = {
+              includes = lib.mkForce [
+                "*.ts"
+              ];
+            };
+          };
+          settings.global.on-unmatched = "info";
+          settings.global.excludes = [
+            ".yarn/*"
+          ];
+        };
       in
       {
         packages = rec {
@@ -58,6 +111,7 @@
               yarn up -E @yarnpkg/cli @yarnpkg/core @yarnpkg/fslib @yarnpkg/libzip @yarnpkg/plugin-file @yarnpkg/plugin-pnp @yarnpkg/pnp @yarnpkg/builder
             '';
           };
+
           tests = {
             patch =
               let
@@ -78,17 +132,14 @@
               '';
           };
         };
+        treefmt-config = treefmt-eval.config;
         devShells = {
           default = pkgs.mkShell {
             packages = with pkgs; [
               nodejs
               yarnBerry
               pkgs-latest.nixfmt-rfc-style
-              (pkgs-latest.nixfmt-tree.override {
-                settings.formatter.nixfmt.excludes = [
-                  "yarn-manifest.nix"
-                ];
-              })
+              treefmt-eval.config.build.wrapper
             ];
           };
           tests-patch = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "yarnpnp2nix";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs?rev=566e53c2ad750c84f6d31f9ccb9d00f823165550;
+    nixpkgs.url = github:nixos/nixpkgs?rev=95ea544c84ebed84a31896b0ecea2570e5e0e236;
     utils.url = github:numtide/flake-utils;
     flake-compat ={
       url = "github:edolstra/flake-compat";

--- a/lib/.pnp.loader.mjs
+++ b/lib/.pnp.loader.mjs
@@ -131,7 +131,7 @@ async function copyImpl(prelayout, postlayout, destinationFs, destination, sourc
 async function maybeLStat(baseFs, p) {
   try {
     return await baseFs.lstatPromise(p);
-  } catch (e) {
+  } catch {
     return null;
   }
 }
@@ -482,7 +482,7 @@ class FakeFS {
     let current = Buffer.alloc(0);
     try {
       current = await this.readFilePromise(p);
-    } catch (error) {
+    } catch {
     }
     if (Buffer.compare(current, content) === 0)
       return;
@@ -492,7 +492,7 @@ class FakeFS {
     let current = ``;
     try {
       current = await this.readFilePromise(p, `utf8`);
-    } catch (error) {
+    } catch {
     }
     const normalizedContent = automaticNewlines ? normalizeLineEndings(current, content) : content;
     if (current === normalizedContent)
@@ -510,7 +510,7 @@ class FakeFS {
     let current = Buffer.alloc(0);
     try {
       current = this.readFileSync(p);
-    } catch (error) {
+    } catch {
     }
     if (Buffer.compare(current, content) === 0)
       return;
@@ -520,7 +520,7 @@ class FakeFS {
     let current = ``;
     try {
       current = this.readFileSync(p, `utf8`);
-    } catch (error) {
+    } catch {
     }
     const normalizedContent = automaticNewlines ? normalizeLineEndings(current, content) : content;
     if (current === normalizedContent)
@@ -560,13 +560,13 @@ class FakeFS {
       let pid;
       try {
         [pid] = await this.readJsonPromise(lockPath);
-      } catch (error) {
+      } catch {
         return Date.now() - startTime < 500;
       }
       try {
         process.kill(pid, 0);
         return true;
-      } catch (error) {
+      } catch {
         return false;
       }
     };
@@ -579,7 +579,7 @@ class FakeFS {
             try {
               await this.unlinkPromise(lockPath);
               continue;
-            } catch (error2) {
+            } catch {
             }
           }
           if (Date.now() - startTime < 60 * 1e3) {
@@ -599,7 +599,7 @@ class FakeFS {
       try {
         await this.closePromise(fd);
         await this.unlinkPromise(lockPath);
-      } catch (error) {
+      } catch {
       }
     }
   }
@@ -895,7 +895,7 @@ class ProxiedFS extends FakeFS {
   watch(p, a, b) {
     return this.baseFs.watch(
       this.mapToBase(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b
     );
@@ -903,7 +903,7 @@ class ProxiedFS extends FakeFS {
   watchFile(p, a, b) {
     return this.baseFs.watchFile(
       this.mapToBase(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b
     );
@@ -1323,7 +1323,7 @@ class NodeFS extends BasePortableFakeFS {
   watch(p, a, b) {
     return this.realFs.watch(
       npath.fromPortablePath(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b
     );
@@ -1331,7 +1331,7 @@ class NodeFS extends BasePortableFakeFS {
   watchFile(p, a, b) {
     return this.realFs.watchFile(
       npath.fromPortablePath(p),
-      // @ts-expect-error
+      // @ts-expect-error - reason TBS
       a,
       b
     );

--- a/plugin/sources/index.ts
+++ b/plugin/sources/index.ts
@@ -1,4 +1,4 @@
-import { execa, execaSync } from 'execa';
+import { execa, execaSync } from 'execa'
 
 let getExistingManifestNix = require('../../lib/getExistingManifest.nix.txt')
 
@@ -12,20 +12,24 @@ let _nixCurrentSystem: string
 
 function getByValue(map, searchValue) {
   for (let [key, value] of map.entries()) {
-    if (value === searchValue)
-      return key;
+    if (value === searchValue) {
+      return key
+    }
   }
 }
 
 export function nixCurrentSystem() {
   if (!!_nixCurrentSystem) return _nixCurrentSystem
-  const res = JSON.parse(execaSync('nix', [
-    'eval',
-    '--impure',
-    '--json',
-    '--expr',
-    'builtins.currentSystem',
-  ]).stdout)
+  const res = JSON.parse(
+    execaSync('nix', [
+      'eval',
+      '--impure',
+      '--json',
+      '--expr',
+      'builtins.currentSystem',
+    ])
+      .stdout,
+  )
   _nixCurrentSystem = res
   return res
 }
@@ -37,9 +41,9 @@ export async function getExistingYarnManifest(manifestPath: string) {
       '--json',
       '--impure',
       '--expr',
-      getExistingManifestNix +
-        '\n' +
-        `
+      getExistingManifestNix
+      + '\n'
+      + `
         getPackages (import ${manifestPath})
       `,
     ]
@@ -50,14 +54,36 @@ export async function getExistingYarnManifest(manifestPath: string) {
   }
 }
 
-import { Configuration, Project, Cache, StreamReport, Manifest, tgzUtils, hashUtils, structUtils, miscUtils, scriptUtils, Workspace, Linker, Installer } from "@yarnpkg/core";
-import { BaseCommand } from '@yarnpkg/cli';
-import { xfs, CwdFS, PortablePath, VirtualFS, ppath, npath, Filename } from '@yarnpkg/fslib';
-import { ZipOpenFS } from '@yarnpkg/libzip';
-import { getPnpPath, pnpUtils } from '@yarnpkg/plugin-pnp';
-import { fileUtils } from '@yarnpkg/plugin-file';
-import { Option } from 'clipanion';
-import t from 'typanion';
+import { BaseCommand } from '@yarnpkg/cli'
+import {
+  Cache,
+  Configuration,
+  hashUtils,
+  Installer,
+  Linker,
+  Manifest,
+  miscUtils,
+  Project,
+  scriptUtils,
+  StreamReport,
+  structUtils,
+  tgzUtils,
+  Workspace,
+} from '@yarnpkg/core'
+import {
+  CwdFS,
+  Filename,
+  npath,
+  PortablePath,
+  ppath,
+  VirtualFS,
+  xfs,
+} from '@yarnpkg/fslib'
+import { ZipOpenFS } from '@yarnpkg/libzip'
+import { fileUtils } from '@yarnpkg/plugin-file'
+import { getPnpPath, pnpUtils } from '@yarnpkg/plugin-pnp'
+import { Option } from 'clipanion'
+import t from 'typanion'
 
 const { toPortablePath } = npath
 
@@ -69,19 +95,25 @@ const debug = (...args) => {
 
 // Copied from: https://github.com/yarnpkg/berry/blob/5cebf76352881fab6ed039762a7eb08143d04c0b/packages/yarnpkg-core/sources/Cache.ts#L412-L415
 function getHashComponent(checksum: string) {
-  const split = checksum.indexOf(`/`);
-  return split !== -1 ? checksum.slice(split + 1) : checksum;
+  const split = checksum.indexOf(`/`)
+  return split !== -1 ? checksum.slice(split + 1) : checksum
 }
 
 class FetchCommand extends BaseCommand {
   static paths = [['nix', 'fetch-by-locator']]
 
-  locator = Option.String({validator: t.isString()})
-  outDirectory = Option.String({validator: t.isString()})
+  locator = Option.String({ validator: t.isString() })
+  outDirectory = Option.String({ validator: t.isString() })
 
   async execute() {
-    const configuration = await Configuration.find(ppath.cwd(), this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, ppath.cwd());
+    const configuration = await Configuration.find(
+      ppath.cwd(),
+      this.context.plugins,
+    )
+    const { project, workspace } = await Project.find(
+      configuration,
+      ppath.cwd(),
+    )
 
     const fetcher = configuration.makeFetcher()
 
@@ -103,42 +135,54 @@ class FetchCommand extends BaseCommand {
       }
 
       const fetchOptions = {
-        checksums: new Map(), project, cache: new Cache(
+        checksums: new Map(),
+        project,
+        cache: new Cache(
           toPortablePath(this.outDirectory),
-          { check: false, configuration, immutable: false }
+          { check: false, configuration, immutable: false },
         ),
         fetcher,
-        report
+        report,
       }
       const fetched = await fetcher.fetch(locator, fetchOptions)
 
       fs.renameSync(
         // @ts-expect-error
         fetched.packageFs.target,
-        path.join(this.outDirectory, 'output.zip')
+        path.join(this.outDirectory, 'output.zip'),
       )
-    });
+    })
   }
 }
 
 class CreateLockFileCommand extends BaseCommand {
   static paths = [['nix', 'create-lockfile']]
 
-  packageRegistryDataPath = Option.String({validator: t.isString()})
+  packageRegistryDataPath = Option.String({ validator: t.isString() })
 
   async execute() {
-    const configuration = await Configuration.find(ppath.cwd(), this.context.plugins);
+    const configuration = await Configuration.find(
+      ppath.cwd(),
+      this.context.plugins,
+    )
 
     const project = new Project(ppath.cwd(), { configuration })
     // @ts-expect-error
     await project.setupResolutions()
 
-    const packageRegistryData = JSON.parse(fs.readFileSync(this.packageRegistryDataPath, 'utf8'))
+    const packageRegistryData = JSON.parse(
+      fs.readFileSync(this.packageRegistryDataPath, 'utf8'),
+    )
 
-    const packageRegistryPackages: any[] = Object.values(packageRegistryData).filter((pkg: any) => !!pkg?.manifest)
+    const packageRegistryPackages: any[] = Object
+      .values(packageRegistryData)
+      .filter((pkg: any) => !!pkg?.manifest)
 
     for (const _package of packageRegistryPackages) {
-      const pkg = Object.assign({}, _package.manifest, { name: _package.name, reference: _package.reference })
+      const pkg = Object.assign({}, _package.manifest, {
+        name: _package.name,
+        reference: _package.reference,
+      })
       //  {
       //   identHash: '9ca470fa61f45e067b8912c4342a3400ef0a72ba40cc23c2c0b328fe2213be1f145c35685252f614b708022def6c86380b66b07686cf36dd332caae8d849136f',
       //   scope: null,
@@ -179,14 +223,19 @@ class CreateLockFileCommand extends BaseCommand {
       project.originalPackages.set(
         pkg.locatorHash,
         // @ts-expect-error
-        origPackage
+        origPackage,
       )
 
       // storedResolutions is a map of descriptorHash -> locatorHash
       project.storedResolutions.set(pkg.descriptorHash, pkg.locatorHash)
 
       // storedChecksums is a map of locatorHash -> checksum
-      if (pkg.checksum != null) project.storedChecksums.set(pkg.locatorHash, pkg.checksum)
+      if (pkg.checksum != null) {
+        project.storedChecksums.set(
+          pkg.locatorHash,
+          pkg.checksum,
+        )
+      }
 
       project.storedDescriptors.set(pkg.descriptorHash, descriptor)
     }
@@ -199,11 +248,18 @@ class CreateLockFileCommand extends BaseCommand {
 
       for (const dependencyName of Object.keys(pkgDependencies)) {
         const [depPkgName, depPkgReference] = pkgDependencies[dependencyName]
-        const depPkg = packageRegistryPackages.find(pkg => pkg?.name === depPkgName && pkg?.reference === depPkgReference)
+        const depPkg = packageRegistryPackages.find(pkg =>
+          pkg?.name === depPkgName && pkg?.reference === depPkgReference
+        )
         if (depPkg?.manifest?.descriptorHash != null) {
-          const depPkgDescriptor = project.storedDescriptors.get(depPkg.manifest.descriptorHash)
+          const depPkgDescriptor = project.storedDescriptors.get(
+            depPkg.manifest.descriptorHash,
+          )
           if (depPkgDescriptor != null) {
-            pkg.dependencies.set(depPkg.manifest.descriptorHash, depPkgDescriptor)
+            pkg.dependencies.set(
+              depPkg.manifest.descriptorHash,
+              depPkgDescriptor,
+            )
           }
         }
       }
@@ -218,13 +274,19 @@ class CreateLockFileCommand extends BaseCommand {
 class ConvertToZipCommand extends BaseCommand {
   static paths = [['nix', 'convert-to-zip']]
 
-  locator = Option.String({validator: t.isString()})
-  tgzPath = Option.String({validator: t.isString()})
-  outPath = Option.String({validator: t.isString()})
+  locator = Option.String({ validator: t.isString() })
+  tgzPath = Option.String({ validator: t.isString() })
+  outPath = Option.String({ validator: t.isString() })
 
   async execute() {
-    const configuration = await Configuration.find(ppath.cwd(), this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, ppath.cwd());
+    const configuration = await Configuration.find(
+      ppath.cwd(),
+      this.context.plugins,
+    )
+    const { project, workspace } = await Project.find(
+      configuration,
+      ppath.cwd(),
+    )
 
     const locator = {
       ...(JSON.parse(this.locator)),
@@ -245,27 +307,41 @@ class ConvertToZipCommand extends BaseCommand {
 class GeneratePnpFile extends BaseCommand {
   static paths = [['nix', 'generate-pnp-file']]
 
-  outDirectory = Option.String({validator: t.isString()})
-  packageRegistryDataPath = Option.String({validator: t.isString()})
-  topLevelPackageLocator = Option.String({validator: t.isString()})
+  outDirectory = Option.String({ validator: t.isString() })
+  packageRegistryDataPath = Option.String({ validator: t.isString() })
+  topLevelPackageLocator = Option.String({ validator: t.isString() })
 
   async execute() {
-    const configuration = await Configuration.find(ppath.cwd(), this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, ppath.cwd());
+    const configuration = await Configuration.find(
+      ppath.cwd(),
+      this.context.plugins,
+    )
+    const { project, workspace } = await Project.find(
+      configuration,
+      ppath.cwd(),
+    )
 
-    const pnpPath = ppath.join(toPortablePath(this.outDirectory), Filename.pnpCjs)
+    const pnpPath = ppath.join(
+      toPortablePath(this.outDirectory),
+      Filename.pnpCjs,
+    )
 
-    const pnpFallbackMode = project.configuration.get(`pnpFallbackMode`);
+    const pnpFallbackMode = project.configuration.get(`pnpFallbackMode`)
 
-    const dependencyTreeRoots = [] //project.workspaces.map(({anchoredLocator}) => ({name: structUtils.stringifyIdent(anchoredLocator), reference: anchoredLocator.reference}));
-    const enableTopLevelFallback = pnpFallbackMode !== `none`;
-    const fallbackPool = new Map();
-    const ignorePattern = miscUtils.buildIgnorePattern([`.yarn/sdks/**`, ...project.configuration.get(`pnpIgnorePatterns`)]);
-    const shebang = project.configuration.get(`pnpShebang`);
+    const dependencyTreeRoots = [] // project.workspaces.map(({anchoredLocator}) => ({name: structUtils.stringifyIdent(anchoredLocator), reference: anchoredLocator.reference}));
+    const enableTopLevelFallback = pnpFallbackMode !== `none`
+    const fallbackPool = new Map()
+    const ignorePattern = miscUtils.buildIgnorePattern([
+      `.yarn/sdks/**`,
+      ...project.configuration.get(`pnpIgnorePatterns`),
+    ])
+    const shebang = project.configuration.get(`pnpShebang`)
 
     const packageRegistry = new Map()
 
-    const packageRegistryData = JSON.parse(fs.readFileSync(this.packageRegistryDataPath, 'utf8'))
+    const packageRegistryData = JSON.parse(
+      fs.readFileSync(this.packageRegistryDataPath, 'utf8'),
+    )
 
     let topLevelPackage = null
 
@@ -275,33 +351,45 @@ class GeneratePnpFile extends BaseCommand {
       const pkg = packageRegistryData[pkgIdent]
       if (!pkg) continue
 
-      const ident = structUtils.makeIdent(pkg.manifest.scope, pkg.manifest.flatName)
+      const ident = structUtils.makeIdent(
+        pkg.manifest.scope,
+        pkg.manifest.flatName,
+      )
       const locator = structUtils.makeLocator(ident, pkg.reference)
 
-      const isVirtual = structUtils.isVirtualLocator(pkg);
+      const isVirtual = structUtils.isVirtualLocator(pkg)
 
       const packageDependencies = new Map()
       const packagePeers = new Set()
 
       for (const descriptor of pkg.manifest?.packagePeers ?? []) {
-        packageDependencies.set(descriptor, null);
-        packagePeers.add(descriptor);
+        packageDependencies.set(descriptor, null)
+        packagePeers.add(descriptor)
       }
 
       if (pkg.packageDependencies != null) {
         for (const dep of Object.keys(pkg.packageDependencies)) {
-          packageDependencies.set(dep, pkg.packageDependencies[dep]);
+          packageDependencies.set(dep, pkg.packageDependencies[dep])
         }
       }
 
-      const packageLocationAbs = pkg.packageLocation ?? (pkg.drvPath + '/node_modules/' + pkg.name)
-      const relativePackageLocation = path.relative(outDirectoryReal, packageLocationAbs)
-      let packageLocation = (relativePackageLocation.startsWith('../') ? relativePackageLocation : ('./' + relativePackageLocation)) + '/'
+      const packageLocationAbs = pkg.packageLocation
+        ?? (pkg.drvPath + '/node_modules/' + pkg.name)
+      const relativePackageLocation = path.relative(
+        outDirectoryReal,
+        packageLocationAbs,
+      )
+      let packageLocation = (relativePackageLocation
+          .startsWith('../')
+        ? relativePackageLocation
+        : ('./' + relativePackageLocation)) + '/'
 
       if (isVirtual) {
         packageLocation = './' + VirtualFS.makeVirtualPath(
           toPortablePath('./.yarn/__virtual__'),
-          structUtils.slugifyLocator(locator), relativePackageLocation) + '/'
+          structUtils.slugifyLocator(locator),
+          relativePackageLocation,
+        ) + '/'
       }
 
       const packageData = {
@@ -312,7 +400,10 @@ class GeneratePnpFile extends BaseCommand {
         // discardFromLookup: fetchResult.discardFromLookup || false,
       }
 
-      miscUtils.getMapWithDefault(packageRegistry, pkg.name).set(pkg.reference, packageData);
+      miscUtils.getMapWithDefault(packageRegistry, pkg.name).set(
+        pkg.reference,
+        packageData,
+      )
 
       if (locator.reference.startsWith('workspace:')) {
         dependencyTreeRoots.push({
@@ -327,40 +418,49 @@ class GeneratePnpFile extends BaseCommand {
     }
 
     if (topLevelPackage != null) {
-      miscUtils.getMapWithDefault(packageRegistry, null).set(null, topLevelPackage);
+      miscUtils.getMapWithDefault(packageRegistry, null).set(
+        null,
+        topLevelPackage,
+      )
     } else {
-      throw new Error('Could not determine topLevelPackage, this is NEEDED for the .pnp.cjs to be correctly generated')
+      throw new Error(
+        'Could not determine topLevelPackage, this is NEEDED for the .pnp.cjs to be correctly generated',
+      )
     }
 
     const pnpSettings = {
       dependencyTreeRoots,
       enableTopLevelFallback,
-      fallbackExclusionList: pnpFallbackMode === `dependencies-only` ? dependencyTreeRoots : [],
+      fallbackExclusionList: pnpFallbackMode === `dependencies-only`
+        ? dependencyTreeRoots
+        : [],
       fallbackPool,
       ignorePattern,
       packageRegistry,
       shebang,
     }
 
-    const loaderFile = generateInlinedScript(pnpSettings);
+    const loaderFile = generateInlinedScript(pnpSettings)
 
     await xfs.changeFilePromise(pnpPath, loaderFile, {
       automaticNewlines: true,
       mode: 0o755,
-    });
+    })
   }
 }
 
 class MakePathWrappers extends BaseCommand {
   static paths = [['nix', 'make-path-wrappers']]
 
-  binWrappersOutDirectory = Option.String({validator: t.isString()})
-  pnpOutDirectory = Option.String({validator: t.isString()})
-  packageRegistryDataPath = Option.String({validator: t.isString()})
-  topLevelPackageLocator = Option.String({validator: t.isString()})
+  binWrappersOutDirectory = Option.String({ validator: t.isString() })
+  pnpOutDirectory = Option.String({ validator: t.isString() })
+  packageRegistryDataPath = Option.String({ validator: t.isString() })
+  topLevelPackageLocator = Option.String({ validator: t.isString() })
 
   async execute() {
-    const packageRegistryData = JSON.parse(fs.readFileSync(this.packageRegistryDataPath, 'utf8'))
+    const packageRegistryData = JSON.parse(
+      fs.readFileSync(this.packageRegistryDataPath, 'utf8'),
+    )
 
     const outDirectoryReal = fs.realpathSync(this.pnpOutDirectory)
 
@@ -368,30 +468,49 @@ class MakePathWrappers extends BaseCommand {
       const pkg = packageRegistryData[pkgIdent]
       if (!pkg) continue
 
-      const ident = structUtils.makeIdent(pkg.manifest.scope, pkg.manifest.flatName)
+      const ident = structUtils.makeIdent(
+        pkg.manifest.scope,
+        pkg.manifest.flatName,
+      )
       const locator = structUtils.makeLocator(ident, pkg.reference)
 
-      const isVirtual = structUtils.isVirtualLocator(pkg);
+      const isVirtual = structUtils.isVirtualLocator(pkg)
 
-      const packageLocationAbs = pkg.packageLocation ?? (pkg.drvPath + '/node_modules/' + pkg.name)
-      const relativePackageLocation = path.relative(outDirectoryReal, packageLocationAbs)
+      const packageLocationAbs = pkg.packageLocation
+        ?? (pkg.drvPath + '/node_modules/' + pkg.name)
+      const relativePackageLocation = path.relative(
+        outDirectoryReal,
+        packageLocationAbs,
+      )
       let packageLocation = packageLocationAbs
 
-      const isTopLevelPackage = `${pkg.name}@${pkg.reference}` === this.topLevelPackageLocator
+      const isTopLevelPackage = `${pkg.name}@${pkg.reference}` === this
+        .topLevelPackageLocator
       if (isTopLevelPackage) continue
 
       if (isVirtual) {
-        packageLocation = path.join(outDirectoryReal, VirtualFS.makeVirtualPath(
-          toPortablePath('./.yarn/__virtual__'),
-          structUtils.slugifyLocator(locator), relativePackageLocation)
+        packageLocation = path.join(
+          outDirectoryReal,
+          VirtualFS.makeVirtualPath(
+            toPortablePath('./.yarn/__virtual__'),
+            structUtils.slugifyLocator(locator),
+            relativePackageLocation,
+          ),
         )
       }
 
       for (const bin of Object.keys(pkg?.manifest?.bin ?? {})) {
-        const resolvedBinPath = path.join(packageLocation, pkg.manifest.bin[bin])
-        await xfs.writeFilePromise(path.join(this.binWrappersOutDirectory, bin), `node ${resolvedBinPath} "$@"`, {
-          mode: 0o755,
-        })
+        const resolvedBinPath = path.join(
+          packageLocation,
+          pkg.manifest.bin[bin],
+        )
+        await xfs.writeFilePromise(
+          path.join(this.binWrappersOutDirectory, bin),
+          `node ${resolvedBinPath} "$@"`,
+          {
+            mode: 0o755,
+          },
+        )
       }
     }
   }
@@ -400,13 +519,19 @@ class MakePathWrappers extends BaseCommand {
 class RunBuildScriptsCommand extends BaseCommand {
   static paths = [['nix', 'run-build-scripts']]
 
-  locator = Option.String({validator: t.isString()})
-  pnpRootDirectory = Option.String({validator: t.isString()})
-  packageDirectory = Option.String({validator: t.isString()})
+  locator = Option.String({ validator: t.isString() })
+  pnpRootDirectory = Option.String({ validator: t.isString() })
+  packageDirectory = Option.String({ validator: t.isString() })
 
   async execute() {
-    const configuration = await Configuration.find(ppath.cwd(), this.context.plugins);
-    const {project, workspace} = await Project.find(configuration, ppath.cwd());
+    const configuration = await Configuration.find(
+      ppath.cwd(),
+      this.context.plugins,
+    )
+    const { project, workspace } = await Project.find(
+      configuration,
+      ppath.cwd(),
+    )
 
     const _locator = JSON.parse(this.locator)
     const ident = structUtils.makeIdent(_locator.scope, _locator.name)
@@ -418,22 +543,37 @@ class RunBuildScriptsCommand extends BaseCommand {
 
     // need to find a way to make this work without restoring install state...
     // await project.restoreInstallState({
-      //   restoreResolutions: true,
-      // });
+    //   restoreResolutions: true,
+    // });
     project.storedPackages = project.originalPackages
     // next thing to fix is "couldn't find XXX in the currently installed PnP map"
 
-    const manifest = await ZipOpenFS.openPromise(async (zipOpenFs) => {
-      const linkers = project.configuration.getLinkers();
-      const linkerOptions = {project, report: new StreamReport({stdout: new PassThrough(), configuration})};
+    const manifest = await ZipOpenFS.openPromise(async zipOpenFs => {
+      const linkers = project.configuration.getLinkers()
+      const linkerOptions = {
+        project,
+        report: new StreamReport({ stdout: new PassThrough(), configuration }),
+      }
 
-      const linker = linkers.find(linker => linker.supportsPackage(pkg, linkerOptions));
-      if (!linker)
-        throw new Error(`The package ${structUtils.prettyLocator(project.configuration, pkg)} isn't supported by any of the available linkers`);
+      const linker = linkers.find(linker =>
+        linker.supportsPackage(pkg, linkerOptions)
+      )
+      if (!linker) {
+        throw new Error(
+          `The package ${
+            structUtils.prettyLocator(project.configuration, pkg)
+          } isn't supported by any of the available linkers`,
+        )
+      }
 
-      const packageLocation = await linker.findPackageLocation(pkg, linkerOptions);
-      const packageFs = new CwdFS(packageLocation, {baseFs: zipOpenFs});
-      const manifest = await Manifest.find(PortablePath.dot, {baseFs: packageFs});
+      const packageLocation = await linker.findPackageLocation(
+        pkg,
+        linkerOptions,
+      )
+      const packageFs = new CwdFS(packageLocation, { baseFs: zipOpenFs })
+      const manifest = await Manifest.find(PortablePath.dot, {
+        baseFs: packageFs,
+      })
 
       return manifest
     })
@@ -441,13 +581,18 @@ class RunBuildScriptsCommand extends BaseCommand {
     for (const scriptName of [`preinstall`, `install`, `postinstall`]) {
       if (!manifest.scripts.has(scriptName)) continue
 
-      const exitCode = await scriptUtils.executePackageScript(pkg, scriptName, [], {
-        cwd: toPortablePath(this.packageDirectory),
-        project,
-        stdin: process.stdin,
-        stdout: process.stdout,
-        stderr: process.stderr
-      });
+      const exitCode = await scriptUtils.executePackageScript(
+        pkg,
+        scriptName,
+        [],
+        {
+          cwd: toPortablePath(this.packageDirectory),
+          project,
+          stdin: process.stdin,
+          stdout: process.stdout,
+          stderr: process.stderr,
+        },
+      )
 
       if (exitCode > 0) {
         return exitCode
@@ -459,30 +604,36 @@ class RunBuildScriptsCommand extends BaseCommand {
 export default {
   hooks: {
     afterAllInstalled: async (project: Project, opts) => {
-      const linkers = project.configuration.getLinkers();
-      const linkerOptions = {project, report: null};
+      const linkers = project.configuration.getLinkers()
+      const linkerOptions = { project, report: null }
 
       // const existingManifest = await getExistingYarnManifest(path.join(project.cwd, 'yarn-manifest.nix'))
 
       const installers = new Map(linkers.map(linker => {
-        const installer = linker.makeInstaller(linkerOptions);
+        const installer = linker.makeInstaller(linkerOptions)
 
-        const customDataKey = linker.getCustomDataKey();
-        const customData = project.linkersCustomData.get(customDataKey);
-        if (typeof customData !== `undefined`)
-          installer.attachCustomData(customData);
+        const customDataKey = linker.getCustomDataKey()
+        const customData = project.linkersCustomData.get(customDataKey)
+        if (typeof customData !== `undefined`) {
+          installer.attachCustomData(customData)
+        }
 
-        return [linker, installer];
-      }));
+        return [linker, installer]
+      }))
 
-      const cache = await Cache.find(project.configuration);
+      const cache = await Cache.find(project.configuration)
 
+      const fetcher = project.configuration.makeFetcher()
+      const fetchOptions = {
+        checksums: new Map(),
+        project,
+        cache: null,
+        fetcher,
+        report: null,
+      }
 
-      const fetcher = project.configuration.makeFetcher();
-      const fetchOptions = { checksums: new Map(), project, cache: null, fetcher, report: null }
-
-      const resolver = project.configuration.makeResolver();
-      const resolveOptions = {project, report: opts.report, resolver}
+      const resolver = project.configuration.makeResolver()
+      const resolveOptions = { project, report: opts.report, resolver }
 
       const packageManifest: any = {}
 
@@ -495,10 +646,14 @@ export default {
         // }
 
         const canonicalPackage = isVirtual
-          ? project.storedPackages.get(structUtils.devirtualizeLocator(pkg).locatorHash)
+          ? project.storedPackages.get(
+            structUtils.devirtualizeLocator(pkg).locatorHash,
+          )
           : pkg
 
-        const linker = linkers.find(linker => linker.supportsPackage(canonicalPackage, linkerOptions));
+        const linker = linkers.find(linker =>
+          linker.supportsPackage(canonicalPackage, linkerOptions)
+        )
         const installer = installers.get(linker)
 
         let localPath = fetcher.getLocalPath(canonicalPackage, fetchOptions)
@@ -513,7 +668,10 @@ export default {
                 localPath = path.join(project.cwd, pkgPath.slice(2))
               }
             } else {
-              const parentLocalPath = fetcher.getLocalPath(parentLocator, fetchOptions)
+              const parentLocalPath = fetcher.getLocalPath(
+                parentLocator,
+                fetchOptions,
+              )
               const resolvedPath = path.resolve(parentLocalPath, pkgPath)
               if (resolvedPath != null) {
                 localPath = resolvedPath
@@ -522,9 +680,13 @@ export default {
           }
         }
 
-        const localPathRelative = localPath != null ? './' + path.relative(project.cwd, localPath) : null
+        const localPathRelative = localPath != null
+          ? './' + path.relative(project.cwd, localPath)
+          : null
 
-        const src = pkg.reference.startsWith('workspace:') ? `./${pkg.reference.substring('workspace:'.length)}` : (localPathRelative != null ? localPathRelative : null)
+        const src = pkg.reference.startsWith('workspace:')
+          ? `./${pkg.reference.substring('workspace:'.length)}`
+          : (localPathRelative != null ? localPathRelative : null)
         const bin = pkg.bin != null ? Object.fromEntries(pkg.bin) : null
 
         const shouldBeUnplugged = src != null
@@ -533,10 +695,17 @@ export default {
           : (installer?.shouldBeUnplugged != null
             // @ts-expect-error
             ? installer.customData.store.get(pkg.locatorHash) != null
-            // @ts-expect-error
-              ? installer.shouldBeUnplugged(pkg, installer.customData.store.get(pkg.locatorHash), project.getDependencyMeta(structUtils.isVirtualLocator(pkg)
-                ? structUtils.devirtualizeLocator(pkg)
-                : pkg, pkg.version))
+              // @ts-expect-error
+              ? installer.shouldBeUnplugged(
+                pkg,
+                installer.customData.store.get(pkg.locatorHash),
+                project.getDependencyMeta(
+                  structUtils.isVirtualLocator(pkg)
+                    ? structUtils.devirtualizeLocator(pkg)
+                    : pkg,
+                  pkg.version,
+                ),
+              )
               : false
             : true)
 
@@ -547,7 +716,9 @@ export default {
         let installCondition = null
 
         if (pkg.conditions != null) {
-          const conditions = pkg.conditions.split('&').map(part => part.trim().split('='))
+          const conditions = pkg.conditions.split('&').map(part =>
+            part.trim().split('=')
+          )
           let nixConditions = []
 
           for (const condition of conditions) {
@@ -563,10 +734,10 @@ export default {
               }
             } else if (key === 'cpu') {
               const cpuMapping: any = {
-                'ia32': 'stdenv.isi686',
-                'x64': 'stdenv.isx86_64',
-                'arm': 'stdenv.isAarch32',
-                'arm64': 'stdenv.isAarch64',
+                ia32: 'stdenv.isi686',
+                x64: 'stdenv.isx86_64',
+                arm: 'stdenv.isAarch32',
+                arm64: 'stdenv.isAarch64',
               }
               if (cpuMapping[v] != null) {
                 nixConditions.push(cpuMapping[v])
@@ -582,28 +753,50 @@ export default {
           }
 
           if (nixConditions.length > 0) {
-            installCondition = `stdenv: ${nixConditions.map(cond => `(${cond})`).join(' && ')}`
+            installCondition = `stdenv: ${
+              nixConditions.map(cond => `(${cond})`).join(' && ')
+            }`
           }
         }
 
         let pkgDependencies = pkg.dependencies
         let pkgDevDependencies = new Map()
 
-        const shouldLookupDevDependencies = canonicalPackage.reference.startsWith('workspace:')
+        const shouldLookupDevDependencies = canonicalPackage
+          .reference
+          .startsWith('workspace:')
 
         // lookup devDependencies from manifests for workspace: packages
         if (shouldLookupDevDependencies) {
-          const manifest = await ZipOpenFS.openPromise(async (zipOpenFs) => {
-            const linkers = project.configuration.getLinkers();
-            const linkerOptions = {project, report: new StreamReport({stdout: new PassThrough(), configuration: project.configuration})};
+          const manifest = await ZipOpenFS.openPromise(async zipOpenFs => {
+            const linkers = project.configuration.getLinkers()
+            const linkerOptions = {
+              project,
+              report: new StreamReport({
+                stdout: new PassThrough(),
+                configuration: project.configuration,
+              }),
+            }
 
-            const linker = linkers.find(linker => linker.supportsPackage(canonicalPackage, linkerOptions));
-            if (!linker)
-              throw new Error(`The package ${structUtils.prettyLocator(project.configuration, pkg)} isn't supported by any of the available linkers`);
+            const linker = linkers.find(linker =>
+              linker.supportsPackage(canonicalPackage, linkerOptions)
+            )
+            if (!linker) {
+              throw new Error(
+                `The package ${
+                  structUtils.prettyLocator(project.configuration, pkg)
+                } isn't supported by any of the available linkers`,
+              )
+            }
 
-            const packageLocation = await linker.findPackageLocation(canonicalPackage, linkerOptions);
-            const packageFs = new CwdFS(packageLocation, {baseFs: zipOpenFs});
-            const manifest = await Manifest.find(PortablePath.dot, {baseFs: packageFs});
+            const packageLocation = await linker
+              .findPackageLocation(canonicalPackage, linkerOptions)
+            const packageFs = new CwdFS(packageLocation, { baseFs: zipOpenFs })
+            const manifest = await Manifest
+              .find(
+                PortablePath.dot,
+                { baseFs: packageFs },
+              )
 
             return manifest
           })
@@ -612,37 +805,53 @@ export default {
             pkgDependencies = new Map()
             pkgDevDependencies = new Map()
 
-            if (manifest.devDependencies) {
-              Array.from(manifest.devDependencies).map(([key, value]) => pkgDevDependencies.set(key, pkg.dependencies.get(key)))
+            if (
+              manifest.devDependencies
+            ) {
+              Array.from(manifest.devDependencies).map(([key, value]) =>
+                pkgDevDependencies.set(key, pkg.dependencies.get(key))
+              )
               Array.from(pkg.dependencies).map(([key, value]) =>
-                !pkgDevDependencies.has(key) ? pkgDependencies.set(key, value) : null
+                !pkgDevDependencies.has(key)
+                  ? pkgDependencies.set(key, value)
+                  : null
               )
             }
           }
         }
 
-        const processDendencies = deps => Promise.all(Array.from(deps).map(async ([key, value]) => {
-          if (!value) {
-            debug(`failed to resolve pkg ${key}`, value)
-            return null
-          }
-          const resolutionHash = project.storedResolutions.get(value.descriptorHash)
-          let resolvedPkg = resolutionHash != null ? project.storedPackages.get(resolutionHash) :
-            null
-          if (!resolvedPkg) {
-            debug(`failed to resolve pkg ${key}`, value)
-            return null
-          }
-          // reference virtual packages instead so that peerDependencies are respected
-          // if (structUtils.isVirtualLocator(resolvedPkg)) {
-          //   resolvedPkg = structUtils.devirtualizeLocator(resolvedPkg)
-          // }
-          return {
-            key,
-            name: structUtils.stringifyIdent(value),
-            packageManifestId: structUtils.stringifyIdent(resolvedPkg) + '@' + resolvedPkg.reference,
-          }
-        })).then(xs => xs.filter(pkg => !!pkg))
+        const processDendencies = deps =>
+          Promise
+            .all(
+              Array.from(deps).map(async ([key, value]) => {
+                if (!value) {
+                  debug(`failed to resolve pkg ${key}`, value)
+                  return null
+                }
+                const resolutionHash = project.storedResolutions.get(
+                  value.descriptorHash,
+                )
+                let resolvedPkg = resolutionHash != null
+                  ? project.storedPackages.get(resolutionHash)
+                  : null
+                if (!resolvedPkg) {
+                  debug(`failed to resolve pkg ${key}`, value)
+                  return null
+                }
+                // reference virtual packages instead so that peerDependencies are respected
+                // if (structUtils.isVirtualLocator(resolvedPkg)) {
+                //   resolvedPkg = structUtils.devirtualizeLocator(resolvedPkg)
+                // }
+                return {
+                  key,
+                  name: structUtils.stringifyIdent(value),
+                  packageManifestId: structUtils.stringifyIdent(resolvedPkg)
+                    + '@'
+                    + resolvedPkg.reference,
+                }
+              }),
+            )
+            .then(xs => xs.filter(pkg => !!pkg))
 
         const dependencies = await processDendencies(pkgDependencies)
         const devDependencies = await processDendencies(pkgDevDependencies)
@@ -650,10 +859,11 @@ export default {
         const packagePeers = []
 
         for (const descriptor of pkg.peerDependencies.values()) {
-          packagePeers.push(structUtils.stringifyIdent(descriptor));
+          packagePeers.push(structUtils.stringifyIdent(descriptor))
         }
 
-        const manifestPackageId = structUtils.stringifyIdent(pkg) + '@' + pkg.reference
+        const manifestPackageId = structUtils.stringifyIdent(pkg) + '@' + pkg
+          .reference
 
         // const packageInExistingManifest = existingManifest?.[manifestPackageId]
 
@@ -668,11 +878,12 @@ export default {
             return
           } else if (willOutputBeZip) {
             // simple, use the hash of the zip file
-            outputHash = getHashComponent(project.storedChecksums.get(pkg.locatorHash) ?? '')
+            outputHash = getHashComponent(
+              project.storedChecksums.get(pkg.locatorHash) ?? '',
+            )
             outputHashByPlatform = null
             return
           } else if (shouldBeUnplugged) {
-
             // const shouldHashBePlatformSpecific = true // TODO only if package or dependencies have platform conditions maybe?
             // if (shouldHashBePlatformSpecific) {
             //   if (outputHashByPlatform[nixCurrentSystem()] && !isSourcePatch) {
@@ -698,7 +909,9 @@ export default {
             //     }
             //   }
             // }
-            outputHash = getHashComponent(project.storedChecksums.get(pkg.locatorHash) ?? '')
+            outputHash = getHashComponent(
+              project.storedChecksums.get(pkg.locatorHash) ?? '',
+            )
             if (!outputHash) {
               debug('got package unplugged package with no hash', pkg)
               try {
@@ -717,7 +930,10 @@ export default {
           }
         })()
 
-        const descriptorHash = getByValue(project.storedResolutions, pkg.locatorHash)
+        const descriptorHash = getByValue(
+          project.storedResolutions,
+          pkg.locatorHash,
+        )
         const descriptor = project.storedDescriptors.get(descriptorHash)
         const yarnChecksum = project.storedChecksums.get(pkg.locatorHash)
 
@@ -730,8 +946,12 @@ export default {
           outputName: [
             structUtils.stringifyIdent(pkg),
             pkg.version,
-            pkg.locatorHash.substring(0, 10)
-          ].filter(part => !!part).join('-').replace(/@/g, '').replace(/[\/]/g, '-'),
+            pkg.locatorHash.substring(0, 10),
+          ]
+            .filter(part => !!part)
+            .join('-')
+            .replace(/@/g, '')
+            .replace(/[\/]/g, '-'),
           outputHash,
           outputHashByPlatform,
           src,
@@ -754,8 +974,12 @@ export default {
 
       let manifestNix: string[] = []
 
-      manifestNix.push('# This file is generated by running "yarn install" inside your project.')
-      manifestNix.push('# It is essentially a version of yarn.lock that Nix can better understand')
+      manifestNix.push(
+        '# This file is generated by running "yarn install" inside your project.',
+      )
+      manifestNix.push(
+        '# It is essentially a version of yarn.lock that Nix can better understand',
+      )
       manifestNix.push('# Manual changes WILL be lost - proceed with caution!')
       manifestNix.push('let')
       manifestNix.push('  packages = {')
@@ -764,14 +988,19 @@ export default {
         if (dependencies.length > 0) {
           manifestNix.push(`      ${key} = {`)
           for (const dep of dependencies) {
-            manifestNix.push(`        ${JSON.stringify(dep.name)} = packages.${JSON.stringify(dep.packageManifestId)};`)
+            manifestNix.push(
+              `        ${JSON.stringify(dep.name)} = packages.${
+                JSON.stringify(dep.packageManifestId)
+              };`,
+            )
           }
           manifestNix.push(`      };`)
         }
       }
 
-      const alphabeticalKeys =
-        Object.keys(packageManifest).sort((a, b) => a.localeCompare(b))
+      const alphabeticalKeys = Object.keys(packageManifest).sort((a, b) =>
+        a.localeCompare(b)
+      )
 
       for (const key of alphabeticalKeys) {
         const pkg = packageManifest[key]
@@ -779,39 +1008,81 @@ export default {
         manifestNix.push(`      name = ${JSON.stringify(pkg.name)};`)
         manifestNix.push(`      reference = ${JSON.stringify(pkg.reference)};`)
         if (pkg.isVirtual && pkg.canonicalPackage != null) {
-          manifestNix.push(`      canonicalPackage = packages.${JSON.stringify(`${structUtils.stringifyIdent(pkg.canonicalPackage)}@${pkg.canonicalPackage.reference}`)};`)
+          manifestNix.push(
+            `      canonicalPackage = packages.${
+              JSON.stringify(`${
+                structUtils.stringifyIdent(
+                  pkg.canonicalPackage,
+                )
+              }@${pkg.canonicalPackage.reference}`)
+            };`,
+          )
         }
         if (!pkg.isVirtual) {
           manifestNix.push(`      linkType = ${JSON.stringify(pkg.linkType)};`)
-          manifestNix.push(`      outputName = ${JSON.stringify(pkg.outputName)};`)
-          if (pkg.outputHash != null)
-            manifestNix.push(`      outputHash = ${JSON.stringify(pkg.outputHash)};`)
-          if (pkg.outputHashByPlatform && Object.keys(pkg.outputHashByPlatform).length > 0) {
+          manifestNix.push(
+            `      outputName = ${JSON.stringify(pkg.outputName)};`,
+          )
+          if (pkg.outputHash != null) {
+            manifestNix.push(
+              `      outputHash = ${JSON.stringify(pkg.outputHash)};`,
+            )
+          }
+          if (
+            pkg.outputHashByPlatform
+            && Object.keys(pkg.outputHashByPlatform).length > 0
+          ) {
             manifestNix.push(`      outputHashByPlatform = {`)
-            for (const outputHashByPlatform of Object.keys(pkg.outputHashByPlatform)) {
-              manifestNix.push(`        ${JSON.stringify(outputHashByPlatform)} = ${JSON.stringify(pkg.outputHashByPlatform[outputHashByPlatform])};`)
+            for (
+              const outputHashByPlatform of Object.keys(
+                pkg.outputHashByPlatform,
+              )
+            ) {
+              manifestNix.push(
+                `        ${JSON.stringify(outputHashByPlatform)} = ${
+                  JSON.stringify(pkg.outputHashByPlatform[outputHashByPlatform])
+                };`,
+              )
             }
             manifestNix.push(`      };`)
           }
-          if (pkg.src)
+          if (pkg.src) {
             manifestNix.push(`      src = ${pkg.src};`)
-          if (pkg.shouldBeUnplugged)
-            manifestNix.push(`      shouldBeUnplugged = ${pkg.shouldBeUnplugged};`)
-          if (pkg.installCondition)
-            manifestNix.push(`      installCondition = ${pkg.installCondition};`)
+          }
+          if (pkg.shouldBeUnplugged) {
+            manifestNix.push(
+              `      shouldBeUnplugged = ${pkg.shouldBeUnplugged};`,
+            )
+          }
+          if (pkg.installCondition) {
+            manifestNix.push(
+              `      installCondition = ${pkg.installCondition};`,
+            )
+          }
 
           // other things necessary for recreating lock file that we don't necessarily use
           manifestNix.push(`      flatName = ${JSON.stringify(pkg.flatName)};`)
-          manifestNix.push(`      languageName = ${JSON.stringify(pkg.languageName)};`)
+          manifestNix.push(
+            `      languageName = ${JSON.stringify(pkg.languageName)};`,
+          )
           manifestNix.push(`      scope = ${JSON.stringify(pkg.scope)};`)
-          manifestNix.push(`      descriptorRange = ${JSON.stringify(pkg.descriptor.range)};`)
-          if (pkg.checksum)
-            manifestNix.push(`      checksum = ${JSON.stringify(pkg.checksum)};`)
+          manifestNix.push(
+            `      descriptorRange = ${JSON.stringify(pkg.descriptor.range)};`,
+          )
+          if (pkg.checksum) {
+            manifestNix.push(
+              `      checksum = ${JSON.stringify(pkg.checksum)};`,
+            )
+          }
 
           if (pkg.bin && Object.keys(pkg.bin).length > 0) {
             manifestNix.push(`      bin = {`)
             for (const bin of Object.keys(pkg.bin)) {
-              manifestNix.push(`        ${JSON.stringify(bin)} = ${JSON.stringify(pkg.bin[bin])};`)
+              manifestNix.push(
+                `        ${JSON.stringify(bin)} = ${
+                  JSON.stringify(pkg.bin[bin])
+                };`,
+              )
             }
             manifestNix.push(`      };`)
           }
@@ -836,18 +1107,28 @@ export default {
       manifestNix.push('packages')
       manifestNix.push('')
 
-      fs.writeFileSync(path.join(project.cwd, 'yarn-manifest.nix'), manifestNix.join('\n'), 'utf8')
+      fs.writeFileSync(
+        path.join(project.cwd, 'yarn-manifest.nix'),
+        manifestNix.join('\n'),
+        'utf8',
+      )
     },
     populateYarnPaths: async (project: Project) => {
-      const packageRegistryDataPath = process.env.YARNNIX_PACKAGE_REGISTRY_DATA_PATH
+      const packageRegistryDataPath =
+        process.env.YARNNIX_PACKAGE_REGISTRY_DATA_PATH
       if (!!packageRegistryDataPath) {
-        const packageRegistryData = JSON.parse(fs.readFileSync(packageRegistryDataPath, 'utf8'))
-        const packageRegistryPackages: any[] = Object.values(packageRegistryData).filter((pkg: any) => !!pkg?.manifest)
+        const packageRegistryData = JSON.parse(
+          fs.readFileSync(packageRegistryDataPath, 'utf8'),
+        )
+        const packageRegistryPackages: any[] = Object
+          .values(packageRegistryData)
+          .filter((pkg: any) => !!pkg?.manifest)
 
         for (const pkg of packageRegistryPackages) {
           if (pkg.canonicalReference.startsWith('workspace:')) {
             if (pkg.drvPath !== process.env.out) {
-              const workspaceCwd = pkg.packageLocation ?? path.join(pkg.drvPath, 'node_modules', pkg.name)
+              const workspaceCwd = pkg.packageLocation
+                ?? path.join(pkg.drvPath, 'node_modules', pkg.name)
               const workspace = new Workspace(workspaceCwd, { project })
               await workspace.setup()
               // @ts-expect-error

--- a/runTests.sh
+++ b/runTests.sh
@@ -2,31 +2,29 @@
 
 set -e
 
-system="$(nix eval --impure --json --expr builtins.currentSystem | jq -r)"
-
-nix build -L ".#packages.$system.tests.patch" --no-link -L
+nix build -L ".#tests.patch" --no-link -L
 
 pushd test
 
 nix eval --json .#packages.aarch64-darwin.testa.transitiveRuntimePackages
 
-nix build -L ".#packages.$system.testb"
+nix build -L ".#testb"
 ./result/bin/testb
 
-nix build -L ".#packages.$system.testa"
+nix build -L ".#testa"
 ./result/bin/testa-peer-test
 
-nix build -L ".#packages.$system.testb.package"
+nix build -L ".#testb.package"
 testbPackage=$(realpath ./result)/node_modules/testb
 
-nix build -L ".#packages.$system.testb.shellRuntimeEnvironment"
+nix build -L ".#testb.shellRuntimeEnvironment"
 runShellEnvironmentTest=$(realpath ./result)
 
 pushd "$testbPackage"
 "$runShellEnvironmentTest/bin/testa-test"
 popd
 
-nix develop ".#packages.$system.testb" -c bash <<EOF
+nix develop ".#testb" -c bash <<EOF
 cd $testbPackage
 testa-test
 EOF

--- a/test/flake-compat.nix
+++ b/test/flake-compat.nix
@@ -1,9 +1,9 @@
-import
-  (
-    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
-    fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-      sha256 = lock.nodes.flake-compat.locked.narHash;
-    }
-  )
-  { src = ./.; }
+import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -70,16 +73,52 @@
         "yarnpnp2nix": "yarnpnp2nix"
       }
     },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "yarnpnp2nix",
+          "nixpkgs-latest"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742370146,
+        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
     "utils": {
       "inputs": {
         "flake-utils": "flake-utils"
       },
       "locked": {
-        "lastModified": 1657226504,
-        "narHash": "sha256-GIYNjuq4mJlFgqKsZ+YrgzWm0IpA4axA3MCrdKYj7gs=",
+        "lastModified": 1738591040,
+        "narHash": "sha256-4WNeriUToshQ/L5J+dTSWC5OJIwT39SEP7V7oylndi8=",
         "owner": "gytis-ivaskevicius",
         "repo": "flake-utils-plus",
-        "rev": "2bf0f91643c2e5ae38c1b26893ac2927ac9bd82a",
+        "rev": "afcb15b845e74ac5e998358709b2b5fe42a948d1",
         "type": "github"
       },
       "original": {
@@ -100,6 +139,7 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
         "type": "github"
       }
     },
@@ -110,6 +150,7 @@
           "nixpkgs"
         ],
         "nixpkgs-latest": "nixpkgs-latest",
+        "treefmt-nix": "treefmt-nix",
         "utils": "utils_2"
       },
       "locked": {

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -33,17 +33,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733229606,
-        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
+        "lastModified": 1738644632,
+        "narHash": "sha256-DyvJjOOGmTSkkEfHq0oWkwtZOgejYIB5S865wmf/qos=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "rev": "95ea544c84ebed84a31896b0ecea2570e5e0e236",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "rev": "95ea544c84ebed84a31896b0ecea2570e5e0e236",
         "type": "github"
       }
     },

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -97,12 +97,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-rk3I55oZTD6KlP2e5DVEjhNHUL97tyo1Z/dTvv7cbU0=",
-        "path": "/nix/store/vpyzg8vax79mpq3x21g1z4y0m333g33g-source",
+        "narHash": "sha256-epVROPRFcdYEx9pvtCVNuaFqkWIdz9agjW7x0VKVxnc=",
+        "path": "/nix/store/bzw914mkiclr593pabhwq8rma39qrq1x-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/vpyzg8vax79mpq3x21g1z4y0m333g33g-source",
+        "path": "/nix/store/bzw914mkiclr593pabhwq8rma39qrq1x-source",
         "type": "path"
       }
     }

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -96,15 +96,14 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-epVROPRFcdYEx9pvtCVNuaFqkWIdz9agjW7x0VKVxnc=",
-        "path": "/nix/store/bzw914mkiclr593pabhwq8rma39qrq1x-source",
+        "path": "../.",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/bzw914mkiclr593pabhwq8rma39qrq1x-source",
+        "path": "../.",
         "type": "path"
-      }
+      },
+      "parent": []
     }
   },
   "root": "root",

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -47,6 +47,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-latest": {
+      "locked": {
+        "lastModified": 1742069588,
+        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
@@ -93,6 +109,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "nixpkgs-latest": "nixpkgs-latest",
         "utils": "utils_2"
       },
       "locked": {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -63,7 +63,7 @@
         allYarnPackages = builtins.attrValues yarnPackages;
 
         packages = {
-          inherit pkgs yarnPackages;
+          inherit yarnPackages;
           yarn-plugin = yarnpnp2nix.packages."${pkgs.stdenv.system}".yarn-plugin;
           react = yarnPackages."react@npm:18.2.0";
           esbuild = yarnPackages."esbuild@npm:0.15.10";
@@ -72,11 +72,24 @@
           teste = yarnPackages."teste@workspace:packages/teste";
           sharp = yarnPackages."sharp@npm:0.31.1";
           canvas = yarnPackages."canvas@npm:2.11.2";
-          open = yarnPackages."open@patch:open@npm%3A8.4.0#.yarn/patches/open-npm-8.4.0-df63cfe537::version=8.4.0&hash=caabd2&locator=root-workspace-0b6124%40workspace%3A.";
+          open = yarnPackages."open@patch:open@npm%3A8.4.0#.yarn/patches/open-npm-8.4.0-df63cfe537::version=8.4.0&hash=68ae10&locator=root-workspace-0b6124%40workspace%3A.";
           test-tgz = yarnPackages."test-tgz-redux-saga-core@file:../../localPackageTests/test-tgz-redux-saga-core.tgz#../../localPackageTests/test-tgz-redux-saga-core.tgz::hash=b2ff7c&locator=testb%40workspace%3Apackages%2Ftestb";
         };
+        yarn-packages = {
+          inherit (packages)
+            react
+            esbuild
+            testa
+            testb
+            teste
+            sharp
+            canvas
+            open
+            test-tgz
+          ;
+        };
       in {
-        inherit packages;
+        inherit packages yarn-packages;
         images = {
           testa = pkgs.dockerTools.streamLayeredImage {
             name = "testa";

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -2,7 +2,7 @@
   description = "A very basic flake";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs?rev=566e53c2ad750c84f6d31f9ccb9d00f823165550;
+    nixpkgs.url = github:nixos/nixpkgs?rev=95ea544c84ebed84a31896b0ecea2570e5e0e236;
     utils.url = github:gytis-ivaskevicius/flake-utils-plus;
     yarnpnp2nix.url = "../.";
     yarnpnp2nix.inputs.nixpkgs.follows = "nixpkgs";

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -2,119 +2,157 @@
   description = "A very basic flake";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs?rev=95ea544c84ebed84a31896b0ecea2570e5e0e236;
-    utils.url = github:gytis-ivaskevicius/flake-utils-plus;
+    nixpkgs.url = "github:nixos/nixpkgs?rev=95ea544c84ebed84a31896b0ecea2570e5e0e236";
+    utils.url = "github:gytis-ivaskevicius/flake-utils-plus";
     yarnpnp2nix.url = "../.";
     yarnpnp2nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ self, nixpkgs, utils, yarnpnp2nix }:
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      utils,
+      yarnpnp2nix,
+      ...
+    }:
     utils.lib.mkFlake {
       inherit self inputs;
       sharedOverlays = [ yarnpnp2nix.overlays.default ];
-      outputsBuilder = channels:
-      let
-        pkgs = channels.nixpkgs;
-        mkYarnPackagesFromManifest = yarnpnp2nix.lib."${pkgs.stdenv.system}".mkYarnPackagesFromManifest;
-        yarnPackages = mkYarnPackagesFromManifest {
-          yarnManifest = import ./workspace/yarn-manifest.nix;
-          inherit packageOverrides;
-        };
-        packageOverrides = {
-          "canvas@npm:2.11.2" = {
-            # Let node-gyp find node headers
-            # see:
-            # - https://github.com/NixOS/nixpkgs/issues/195404
-            # - https://github.com/NixOS/nixpkgs/pull/201715#issuecomment-1326799041
-            # note that:
-            #   npm config set nodedir ${pkgs.nodejs}
-            # yields:
-            #   npm ERR! `nodedir` is not a valid npm option
-            # so we use the env var as described in:
-            #   https://github.com/nodejs/node-gyp#environment-variables
-            preInstallScript = "export npm_config_nodedir=${pkgs.nodejs}";
-            buildInputs = with pkgs; ([
-              autoconf zlib gcc automake pkg-config libtool file
-              python3
-              pixman cairo pango libpng libjpeg giflib librsvg libwebp libuuid
-              python3Packages.distutils
-            ] ++ (if pkgs.stdenv.isDarwin then [ darwin.apple_sdk.frameworks.CoreText ] else []));
+      outputsBuilder =
+        channels:
+        let
+          pkgs = channels.nixpkgs;
+          mkYarnPackagesFromManifest = yarnpnp2nix.lib."${pkgs.stdenv.system}".mkYarnPackagesFromManifest;
+          yarnPackages = mkYarnPackagesFromManifest {
+            yarnManifest = import ./workspace/yarn-manifest.nix;
+            inherit packageOverrides;
           };
-          "sharp@npm:0.31.1" = {
-            preInstallScript = "export npm_config_nodedir=${pkgs.nodejs}";
-            buildInputs = with pkgs; [pkg-config vips python3 python3Packages.distutils];
+          packageOverrides = {
+            "canvas@npm:2.11.2" = {
+              # Let node-gyp find node headers
+              # see:
+              # - https://github.com/NixOS/nixpkgs/issues/195404
+              # - https://github.com/NixOS/nixpkgs/pull/201715#issuecomment-1326799041
+              # note that:
+              #   npm config set nodedir ${pkgs.nodejs}
+              # yields:
+              #   npm ERR! `nodedir` is not a valid npm option
+              # so we use the env var as described in:
+              #   https://github.com/nodejs/node-gyp#environment-variables
+              preInstallScript = "export npm_config_nodedir=${pkgs.nodejs}";
+              buildInputs =
+                with pkgs;
+                (
+                  [
+                    autoconf
+                    zlib
+                    gcc
+                    automake
+                    pkg-config
+                    libtool
+                    file
+                    python3
+                    pixman
+                    cairo
+                    pango
+                    libpng
+                    libjpeg
+                    giflib
+                    librsvg
+                    libwebp
+                    libuuid
+                    python3Packages.distutils
+                  ]
+                  ++ (if pkgs.stdenv.isDarwin then [ darwin.apple_sdk.frameworks.CoreText ] else [ ])
+                );
+            };
+            "sharp@npm:0.31.1" = {
+              preInstallScript = "export npm_config_nodedir=${pkgs.nodejs}";
+              buildInputs = with pkgs; [
+                pkg-config
+                vips
+                python3
+                python3Packages.distutils
+              ];
+            };
+            "testa@workspace:packages/testa" = {
+              filterDependencies = dep: dep != "color" && dep != "testf";
+              build = ''
+                echo $PATH
+                tsc --version
+                tsc
+              '';
+            };
+            "testb@workspace:packages/testb" = {
+              build = ''
+                LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.libuuid ]} node build
+                node build
+                webpack --version
+              '';
+            };
           };
-          "testa@workspace:packages/testa" = {
-            filterDependencies = dep: dep != "color" && dep != "testf";
-            build = ''
-              echo $PATH
-              tsc --version
-              tsc
+          allYarnPackages = builtins.attrValues yarnPackages;
+
+          packages = {
+            inherit yarnPackages;
+            yarn-plugin = yarnpnp2nix.packages."${pkgs.stdenv.system}".yarn-plugin;
+            react = yarnPackages."react@npm:18.2.0";
+            esbuild = yarnPackages."esbuild@npm:0.15.10";
+            testa = yarnPackages."testa@workspace:packages/testa";
+            testb = yarnPackages."testb@workspace:packages/testb";
+            teste = yarnPackages."teste@workspace:packages/teste";
+            sharp = yarnPackages."sharp@npm:0.31.1";
+            canvas = yarnPackages."canvas@npm:2.11.2";
+            open =
+              yarnPackages."open@patch:open@npm%3A8.4.0#.yarn/patches/open-npm-8.4.0-df63cfe537::version=8.4.0&hash=68ae10&locator=root-workspace-0b6124%40workspace%3A.";
+            test-tgz =
+              yarnPackages."test-tgz-redux-saga-core@file:../../localPackageTests/test-tgz-redux-saga-core.tgz#../../localPackageTests/test-tgz-redux-saga-core.tgz::hash=b2ff7c&locator=testb%40workspace%3Apackages%2Ftestb";
+          };
+          yarn-packages = {
+            inherit (packages)
+              react
+              esbuild
+              testa
+              testb
+              teste
+              sharp
+              canvas
+              open
+              test-tgz
+              ;
+          };
+        in
+        {
+          inherit packages yarn-packages;
+          images = {
+            testa = pkgs.dockerTools.streamLayeredImage {
+              name = "testa";
+              maxLayers = 1000;
+              config.Cmd = "${packages.testa}/bin/testa-test";
+            };
+            testb = pkgs.dockerTools.streamLayeredImage {
+              name = "testb";
+              maxLayers = 1000;
+              config.Cmd = "${packages.testb}/bin/testb";
+            };
+          };
+          devShell = pkgs.mkShell {
+            packages =
+              with pkgs;
+              [
+                nodejs
+                yarnBerry
+              ]
+              ++ packageOverrides."canvas@npm:2.11.2".buildInputs;
+
+            # inputsFrom = builtins.filter (p: p.shouldBeUnplugged or false) allYarnPackages;
+
+            shellHook = ''
+              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.libuuid ]}
+              export YARN_PLUGINS=${pkgs.yarn-plugin-yarnpnp2nix}
             '';
           };
-          "testb@workspace:packages/testb" = {
-            build = ''
-              LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [pkgs.libuuid]} node build
-              node build
-              webpack --version
-            '';
-          };
         };
-        allYarnPackages = builtins.attrValues yarnPackages;
-
-        packages = {
-          inherit yarnPackages;
-          yarn-plugin = yarnpnp2nix.packages."${pkgs.stdenv.system}".yarn-plugin;
-          react = yarnPackages."react@npm:18.2.0";
-          esbuild = yarnPackages."esbuild@npm:0.15.10";
-          testa = yarnPackages."testa@workspace:packages/testa";
-          testb = yarnPackages."testb@workspace:packages/testb";
-          teste = yarnPackages."teste@workspace:packages/teste";
-          sharp = yarnPackages."sharp@npm:0.31.1";
-          canvas = yarnPackages."canvas@npm:2.11.2";
-          open = yarnPackages."open@patch:open@npm%3A8.4.0#.yarn/patches/open-npm-8.4.0-df63cfe537::version=8.4.0&hash=68ae10&locator=root-workspace-0b6124%40workspace%3A.";
-          test-tgz = yarnPackages."test-tgz-redux-saga-core@file:../../localPackageTests/test-tgz-redux-saga-core.tgz#../../localPackageTests/test-tgz-redux-saga-core.tgz::hash=b2ff7c&locator=testb%40workspace%3Apackages%2Ftestb";
-        };
-        yarn-packages = {
-          inherit (packages)
-            react
-            esbuild
-            testa
-            testb
-            teste
-            sharp
-            canvas
-            open
-            test-tgz
-          ;
-        };
-      in {
-        inherit packages yarn-packages;
-        images = {
-          testa = pkgs.dockerTools.streamLayeredImage {
-            name = "testa";
-            maxLayers = 1000;
-            config.Cmd = "${packages.testa}/bin/testa-test";
-          };
-          testb = pkgs.dockerTools.streamLayeredImage {
-            name = "testb";
-            maxLayers = 1000;
-            config.Cmd = "${packages.testb}/bin/testb";
-          };
-        };
-        devShell = pkgs.mkShell {
-          packages = with pkgs; [
-            nodejs
-            yarnBerry
-          ] ++ packageOverrides."canvas@npm:2.11.2".buildInputs;
-
-          # inputsFrom = builtins.filter (p: p.shouldBeUnplugged or false) allYarnPackages;
-
-          shellHook = ''
-            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [pkgs.libuuid]}
-            export YARN_PLUGINS=${pkgs.yarn-plugin-yarnpnp2nix}
-          '';
-        };
-      };
     };
 }

--- a/test/workspace/packages/testa/example.ts
+++ b/test/workspace/packages/testa/example.ts
@@ -1,5 +1,7 @@
 import subscriptionsTransportWs from 'subscriptions-transport-ws'
 
-console.log('this is an example typescript file to test the typescript compiler works')
+console.log(
+  'this is an example typescript file to test the typescript compiler works',
+)
 
 console.log(subscriptionsTransportWs)

--- a/yarn.nix
+++ b/yarn.nix
@@ -8,9 +8,9 @@
 
 stdenv.mkDerivation {
   name = "yarn-berry";
-  src = builtins.fetchTarball {
-    url = "https://github.com/yarnpkg/berry/archive/refs/tags/@yarnpkg/cli/4.5.3.tar.gz";
-    sha256 = "sha256:1xp2zxhq5c466jsirsv7zjfkfip58kkdaw7v8466b5f5i14kw26b";
+  src = fetchzip {
+    url = "https://github.com/yarnpkg/berry/archive/182046546379f3b4e111c374946b32d92be5d933.tar.gz";
+    sha256 = "sha256:0q0yzswxzqcjh2d1d1gk8755vak77013527y1zpi1lysv31ds388";
   };
 
   phases = [
@@ -21,7 +21,6 @@ stdenv.mkDerivation {
 
   patches = [
     ./yarnPatches/pack-specific-project.patch
-    ./yarnPatches/node-22-experimental-require-module-support.patch
   ];
 
   buildInputs = [

--- a/yarn.nix
+++ b/yarn.nix
@@ -1,4 +1,10 @@
-{ stdenv, rsync, yarn, fetchzip, nodejs }:
+{
+  stdenv,
+  rsync,
+  yarn,
+  fetchzip,
+  nodejs,
+}:
 
 stdenv.mkDerivation {
   name = "yarn-berry";
@@ -7,7 +13,11 @@ stdenv.mkDerivation {
     sha256 = "sha256:1xp2zxhq5c466jsirsv7zjfkfip58kkdaw7v8466b5f5i14kw26b";
   };
 
-  phases = [ "getSource" "patchPhase" "build" ];
+  phases = [
+    "getSource"
+    "patchPhase"
+    "build"
+  ];
 
   patches = [
     ./yarnPatches/pack-specific-project.patch

--- a/yarnPlugin.nix
+++ b/yarnPlugin.nix
@@ -1,8 +1,17 @@
-{ stdenv, lib, yarnBerry, nodejs, writeShellApplication }:
+{
+  stdenv,
+  lib,
+  yarnBerry,
+  nodejs,
+  writeShellApplication,
+}:
 let
   build = writeShellApplication {
     name = "build-yarn-plugin";
-    runtimeInputs = [ yarnBerry nodejs ];
+    runtimeInputs = [
+      yarnBerry
+      nodejs
+    ];
     text = builtins.readFile ./plugin/build.sh;
   };
 in


### PR DESCRIPTION
- **allow-quick-regression-tests**
- **fix inner flake.lock with nix 2.26.3**
- **update nixpkgs**
- **add formatter and fmt nix code**
- **mkYarnPackage.nix: refactor to simplify and reduce duplication**
- **update yarn to 4.7.0**
- **add treefmt-nix with dprtin to format ts files**
- **remove unnecesary system arg in runTests.sh**
- **fmt ts files**
- **improve treefmt config**
- **plugin: hack around type error**
- **get rid of eval getExe warning**
- **update .pnp.loader.mjs: generated by yarn 4.7.0**
