### PR TITLE
store checksums for conditional packages

### DIFF
--- a/yarn.nix
+++ b/yarn.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./yarnPatches/pack-specific-project.patch
+    ./yarnPatches/checksums-for-conditional-locator.patch
   ];
 
   buildInputs = [

--- a/yarnPatches/checksums-for-conditional-locator.patch
+++ b/yarnPatches/checksums-for-conditional-locator.patch
@@ -1,0 +1,22 @@
+diff --git a/packages/yarnpkg-core/sources/Project.ts b/packages/yarnpkg-core/sources/Project.ts
+index 79ca347..e1ffe8c 100644
+--- a/packages/yarnpkg-core/sources/Project.ts
++++ b/packages/yarnpkg-core/sources/Project.ts
+@@ -1095,7 +1095,7 @@ export class Project {
+   async fetchEverything({cache, report, fetcher: userFetcher, mode, persistProject = true}: InstallOptions) {
+     const cacheOptions = {
+       mockedPackages: this.disabledLocators,
+-      unstablePackages: this.conditionalLocators,
++      unstablePackages: this.disabledLocators,
+     };
+ 
+     const fetcher = userFetcher || this.configuration.makeFetcher();
+@@ -1210,7 +1210,7 @@ export class Project {
+   async linkEverything({cache, report, fetcher: optFetcher, mode}: InstallOptions) {
+     const cacheOptions: CacheOptions = {
+       mockedPackages: this.disabledLocators,
+-      unstablePackages: this.conditionalLocators,
++      unstablePackages: this.disabledLocators,
+       skipIntegrityCheck: true,
+     };
+ 


### PR DESCRIPTION
as long as they are in supportedArchitectures there is no reason not to
store the checksum
